### PR TITLE
Fix wrong type for customCSS property for FastCommentsCommentWidgetCo…

### DIFF
--- a/src/fast-comments-comment-widget-config.ts
+++ b/src/fast-comments-comment-widget-config.ts
@@ -112,7 +112,7 @@ export interface FastCommentsCommentWidgetConfig {
   /** Show both relative and absolute dates "11 minutes ago (5/18/2021)". (Customizable via the UI.) */
   absoluteAndRelativeDates?: boolean
   /** A way to use custom CSS. Note that it's more efficient to define the custom CSS via the Widget Customization UI as it removes a network round trip, and does minification. */
-  customCSS?: boolean
+  customCSS?: string
   /** @Deprecated Text like "Show [count] comments". When defined we won't show the comment list. Instead show a link with the given text, which shows the comments upon clicking. (Customizable via the UI.) Retained for backwards compatibility - we suggest you use useShowCommentsToggle with custom translations, instead.*/
   hideCommentsUnderCountTextFormat?: string
   /** Enables a "Show Comments" toggle button. Customize via translations.HIDE_COMMENTS_BUTTON_TEXT and translations.SHOW_COMMENTS_BUTTON_TEXT. */


### PR DESCRIPTION
### Changes:

According to the [documentation](https://docs.fastcomments.com/guide-customizations-and-configuration.html#custom-css) optional `customCss` property should accept `string` not `boolean`.

### Opened question:
What is package publishing flow? Is it automated somehow? There is not information in Readme.